### PR TITLE
feat(status): show Boot in gt status output

### DIFF
--- a/internal/beads/agent_ids.go
+++ b/internal/beads/agent_ids.go
@@ -30,6 +30,12 @@ func DeaconBeadIDTown() string {
 	return TownBeadsPrefix + "-deacon"
 }
 
+// BootBeadIDTown returns the Boot agent bead ID for town-level beads.
+// Boot is the Deacon's watchdog, stored at hq-boot.
+func BootBeadIDTown() string {
+	return TownBeadsPrefix + "-boot"
+}
+
 // DogBeadIDTown returns a Dog agent bead ID for town-level beads.
 // Dogs are town-level agents, so they follow the pattern: hq-dog-<name>
 func DogBeadIDTown(name string) string {

--- a/internal/beads/agent_ids_test.go
+++ b/internal/beads/agent_ids_test.go
@@ -20,6 +20,15 @@ func TestDeaconBeadIDTown(t *testing.T) {
 	}
 }
 
+// TestBootBeadIDTown tests the town-level Boot bead ID.
+func TestBootBeadIDTown(t *testing.T) {
+	got := BootBeadIDTown()
+	want := "hq-boot"
+	if got != want {
+		t.Errorf("BootBeadIDTown() = %q, want %q", got, want)
+	}
+}
+
 // TestDogBeadIDTown tests town-level Dog bead IDs.
 func TestDogBeadIDTown(t *testing.T) {
 	tests := []struct {

--- a/internal/cmd/boot.go
+++ b/internal/cmd/boot.go
@@ -101,6 +101,11 @@ func getBootManager() (*boot.Boot, error) {
 	return boot.New(townRoot), nil
 }
 
+// getBootSessionName returns the Boot session name.
+func getBootSessionName() string {
+	return boot.SessionName
+}
+
 func runBootStatus(cmd *cobra.Command, args []string) error {
 	b, err := getBootManager()
 	if err != nil {

--- a/internal/cmd/status.go
+++ b/internal/cmd/status.go
@@ -443,6 +443,7 @@ func outputStatusText(status TownStatus) error {
 	roleIcons := map[string]string{
 		constants.RoleMayor:    constants.EmojiMayor,
 		constants.RoleDeacon:   constants.EmojiDeacon,
+		constants.RoleBoot:     constants.EmojiBoot,
 		constants.RoleWitness:  constants.EmojiWitness,
 		constants.RoleRefinery: constants.EmojiRefinery,
 		constants.RoleCrew:     constants.EmojiCrew,
@@ -917,9 +918,10 @@ func discoverGlobalAgents(allSessions map[string]bool, allAgentBeads map[string]
 	// Get session names dynamically
 	mayorSession := getMayorSessionName()
 	deaconSession := getDeaconSessionName()
+	bootSession := getBootSessionName()
 
 	// Define agents to discover
-	// Note: Mayor and Deacon are town-level agents with hq- prefix bead IDs
+	// Note: Mayor, Deacon, and Boot are town-level agents with hq- prefix bead IDs
 	agentDefs := []struct {
 		name    string
 		address string
@@ -929,6 +931,7 @@ func discoverGlobalAgents(allSessions map[string]bool, allAgentBeads map[string]
 	}{
 		{"mayor", "mayor/", mayorSession, "coordinator", beads.MayorBeadIDTown()},
 		{"deacon", "deacon/", deaconSession, "health-check", beads.DeaconBeadIDTown()},
+		{"boot", "boot/", bootSession, "boot", beads.BootBeadIDTown()},
 	}
 
 	agents := make([]AgentRuntime, len(agentDefs))

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -137,6 +137,9 @@ const (
 
 	// RoleDeacon is the deacon agent role.
 	RoleDeacon = "deacon"
+
+	// RoleBoot is the boot agent role (Deacon's watchdog).
+	RoleBoot = "boot"
 )
 
 // Role emojis - centralized for easy customization.
@@ -159,6 +162,9 @@ const (
 
 	// EmojiPolecat is the polecat emoji (transient worker).
 	EmojiPolecat = "😺"
+
+	// EmojiBoot is the boot emoji (Deacon's watchdog).
+	EmojiBoot = "🐕"
 )
 
 // RoleEmoji returns the emoji for a given role name.
@@ -176,6 +182,8 @@ func RoleEmoji(role string) string {
 		return EmojiCrew
 	case RolePolecat:
 		return EmojiPolecat
+	case RoleBoot:
+		return EmojiBoot
 	default:
 		return "❓"
 	}


### PR DESCRIPTION
Add Boot (the Deacon's watchdog) to the global agents displayed in gt status, alongside Mayor and Deacon. Boot now shows its running state with the 🐕 emoji.

Changes:
- Add RoleBoot and EmojiBoot to constants
- Add BootBeadIDTown() function for bead lookups
- Add getBootSessionName() helper in cmd/boot.go
- Include Boot in discoverGlobalAgents() in status.go

## Summary
<!-- Brief description of changes -->

## Related Issue
<!-- Link to issue: Fixes #123 or Closes #123 -->

## Changes
<!-- Bullet list of changes -->
-

## Testing
<!-- How did you test these changes? -->
- [ ] Unit tests pass (`go test ./...`)
- [ ] Manual testing performed

## Checklist
- [ ] Code follows project style
- [ ] Documentation updated (if applicable)
- [ ] No breaking changes (or documented in summary)
