### PR TITLE
feat(feed): detect Claude Code and suggest non-interactive flags

### DIFF
--- a/internal/cmd/feed.go
+++ b/internal/cmd/feed.go
@@ -11,6 +11,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/steveyegge/gastown/internal/tmux"
 	"github.com/steveyegge/gastown/internal/tui/feed"
+	"github.com/steveyegge/gastown/internal/ui"
 	"github.com/steveyegge/gastown/internal/workspace"
 	"golang.org/x/term"
 )
@@ -91,6 +92,16 @@ Examples:
 }
 
 func runFeed(cmd *cobra.Command, args []string) error {
+	// Detect Claude Code environment and suggest non-interactive mode
+	if ui.IsAgentMode() && !feedPlain && !feedNoFollow {
+		return fmt.Errorf(`gt feed launches an interactive TUI which doesn't work in Claude Code
+
+Use this instead:
+  gt feed --plain --no-follow    # Show recent events as plain text
+  gt feed --plain --no-follow --since 5m   # Events from last 5 minutes
+  gt feed --plain --no-follow --limit 20   # Last 20 events`)
+	}
+
 	// Must be in a Gas Town workspace
 	townRoot, err := workspace.FindFromCwdOrError()
 	if err != nil {


### PR DESCRIPTION
When gt feed is called from Claude Code (detected via CLAUDE_CODE or GT_AGENT_MODE env vars), return a helpful error message suggesting --plain --no-follow instead of launching the interactive TUI.

## Summary
<!-- Brief description of changes -->

## Related Issue
<!-- Link to issue: Fixes #123 or Closes #123 -->

## Changes
<!-- Bullet list of changes -->
-

## Testing
<!-- How did you test these changes? -->
- [ ] Unit tests pass (`go test ./...`)
- [ ] Manual testing performed

## Checklist
- [ ] Code follows project style
- [ ] Documentation updated (if applicable)
- [ ] No breaking changes (or documented in summary)
