### PR TITLE
fix(feed): require --no-follow in Claude Code, not just --plain

### DIFF
--- a/internal/cmd/feed.go
+++ b/internal/cmd/feed.go
@@ -92,12 +92,12 @@ Examples:
 }
 
 func runFeed(cmd *cobra.Command, args []string) error {
-	// Detect Claude Code environment and suggest non-interactive mode
-	if ui.IsAgentMode() && !feedPlain && !feedNoFollow {
-		return fmt.Errorf(`gt feed launches an interactive TUI which doesn't work in Claude Code
+	// Detect Claude Code environment - require --no-follow to prevent infinite streaming
+	if ui.IsAgentMode() && !feedNoFollow {
+		return fmt.Errorf(`gt feed streams forever by default, which hangs Claude Code
 
-Use this instead:
-  gt feed --plain --no-follow    # Show recent events as plain text
+Use --no-follow to get a snapshot instead:
+  gt feed --plain --no-follow              # Recent events as plain text
   gt feed --plain --no-follow --since 5m   # Events from last 5 minutes
   gt feed --plain --no-follow --limit 20   # Last 20 events`)
 	}


### PR DESCRIPTION
The previous check only blocked the TUI, but --plain without --no-follow still streams forever. Now we require --no-follow in agent mode regardless of other flags, since the infinite streaming is what hangs Claude Code.

## Summary
<!-- Brief description of changes -->

## Related Issue
<!-- Link to issue: Fixes #123 or Closes #123 -->

## Changes
<!-- Bullet list of changes -->
-

## Testing
<!-- How did you test these changes? -->
- [ ] Unit tests pass (`go test ./...`)
- [ ] Manual testing performed

## Checklist
- [ ] Code follows project style
- [ ] Documentation updated (if applicable)
- [ ] No breaking changes (or documented in summary)
