### PR TITLE
fix(config): add BEADS_AUTO_START_DAEMON=false for all agents

### DIFF
--- a/internal/config/env.go
+++ b/internal/config/env.go
@@ -99,6 +99,10 @@ func AgentEnv(cfg AgentEnvConfig) map[string]string {
 		env["BEADS_NO_DAEMON"] = "1"
 	}
 
+	// Prevent daemon auto-start race condition (bd-63o).
+	// All agents should use an existing daemon but never try to start one.
+	env["BEADS_AUTO_START_DAEMON"] = "false"
+
 	// Add optional runtime config directory
 	if cfg.RuntimeConfigDir != "" {
 		env["CLAUDE_CONFIG_DIR"] = cfg.RuntimeConfigDir

--- a/internal/config/env_test.go
+++ b/internal/config/env_test.go
@@ -17,6 +17,7 @@ func TestAgentEnv_Mayor(t *testing.T) {
 	assertEnv(t, env, "GIT_AUTHOR_NAME", "mayor")
 	assertEnv(t, env, "GT_ROOT", "/town")
 	assertEnv(t, env, "BEADS_DIR", "/town/.beads")
+	assertEnv(t, env, "BEADS_AUTO_START_DAEMON", "false")
 	assertNotSet(t, env, "GT_RIG")
 	assertNotSet(t, env, "BEADS_NO_DAEMON")
 }
@@ -36,6 +37,7 @@ func TestAgentEnv_Witness(t *testing.T) {
 	assertEnv(t, env, "GIT_AUTHOR_NAME", "myrig/witness")
 	assertEnv(t, env, "GT_ROOT", "/town")
 	assertEnv(t, env, "BEADS_DIR", "/town/myrig/.beads")
+	assertEnv(t, env, "BEADS_AUTO_START_DAEMON", "false")
 }
 
 func TestAgentEnv_Polecat(t *testing.T) {
@@ -56,6 +58,7 @@ func TestAgentEnv_Polecat(t *testing.T) {
 	assertEnv(t, env, "GIT_AUTHOR_NAME", "Toast")
 	assertEnv(t, env, "BEADS_AGENT_NAME", "myrig/Toast")
 	assertEnv(t, env, "BEADS_NO_DAEMON", "1")
+	assertEnv(t, env, "BEADS_AUTO_START_DAEMON", "false")
 }
 
 func TestAgentEnv_Crew(t *testing.T) {
@@ -76,6 +79,7 @@ func TestAgentEnv_Crew(t *testing.T) {
 	assertEnv(t, env, "GIT_AUTHOR_NAME", "emma")
 	assertEnv(t, env, "BEADS_AGENT_NAME", "myrig/emma")
 	assertEnv(t, env, "BEADS_NO_DAEMON", "1")
+	assertEnv(t, env, "BEADS_AUTO_START_DAEMON", "false")
 }
 
 func TestAgentEnv_Refinery(t *testing.T) {
@@ -93,6 +97,7 @@ func TestAgentEnv_Refinery(t *testing.T) {
 	assertEnv(t, env, "BD_ACTOR", "myrig/refinery")
 	assertEnv(t, env, "GIT_AUTHOR_NAME", "myrig/refinery")
 	assertEnv(t, env, "BEADS_NO_DAEMON", "1")
+	assertEnv(t, env, "BEADS_AUTO_START_DAEMON", "false")
 }
 
 func TestAgentEnv_Deacon(t *testing.T) {
@@ -108,6 +113,7 @@ func TestAgentEnv_Deacon(t *testing.T) {
 	assertEnv(t, env, "GIT_AUTHOR_NAME", "deacon")
 	assertEnv(t, env, "GT_ROOT", "/town")
 	assertEnv(t, env, "BEADS_DIR", "/town/.beads")
+	assertEnv(t, env, "BEADS_AUTO_START_DAEMON", "false")
 	assertNotSet(t, env, "GT_RIG")
 	assertNotSet(t, env, "BEADS_NO_DAEMON")
 }
@@ -125,6 +131,7 @@ func TestAgentEnv_Boot(t *testing.T) {
 	assertEnv(t, env, "GIT_AUTHOR_NAME", "boot")
 	assertEnv(t, env, "GT_ROOT", "/town")
 	assertEnv(t, env, "BEADS_DIR", "/town/.beads")
+	assertEnv(t, env, "BEADS_AUTO_START_DAEMON", "false")
 	assertNotSet(t, env, "GT_RIG")
 	assertNotSet(t, env, "BEADS_NO_DAEMON")
 }


### PR DESCRIPTION
Prevent daemon auto-start race condition (bd-63o) by setting BEADS_AUTO_START_DAEMON=false in AgentEnv for all agent types.

This ensures agents use an existing daemon but never try to start one, avoiding the race where multiple agents auto-start daemons simultaneously.

## Summary
<!-- Brief description of changes -->

## Related Issue
<!-- Link to issue: Fixes #123 or Closes #123 -->

## Changes
<!-- Bullet list of changes -->
-

## Testing
<!-- How did you test these changes? -->
- [ ] Unit tests pass (`go test ./...`)
- [ ] Manual testing performed

## Checklist
- [ ] Code follows project style
- [ ] Documentation updated (if applicable)
- [ ] No breaking changes (or documented in summary)
