### PR TITLE
fix(doctor): remove stale PATH export check

### DIFF
--- a/internal/doctor/claude_settings_check.go
+++ b/internal/doctor/claude_settings_check.go
@@ -368,9 +368,8 @@ func (c *ClaudeSettingsCheck) checkSettings(path, _ string) []string {
 	// Check for required elements based on template
 	// All templates should have:
 	// 1. enabledPlugins
-	// 2. PATH export in hooks
-	// 3. Stop hook with gt costs record (for autonomous)
-	// 4. gt nudge deacon session-started in SessionStart
+	// 2. Stop hook with gt costs record (for autonomous)
+	// 3. gt nudge deacon session-started in SessionStart
 
 	// Check enabledPlugins
 	if _, ok := actual["enabledPlugins"]; !ok {
@@ -381,11 +380,6 @@ func (c *ClaudeSettingsCheck) checkSettings(path, _ string) []string {
 	hooks, ok := actual["hooks"].(map[string]any)
 	if !ok {
 		return append(missing, "hooks")
-	}
-
-	// Check SessionStart hook has PATH export
-	if !c.hookHasPattern(hooks, "SessionStart", "PATH=") {
-		missing = append(missing, "PATH export")
 	}
 
 	// Check SessionStart hook has deacon nudge


### PR DESCRIPTION
## Summary

- Remove the `PATH=` pattern check from `claude-settings` doctor check
- The PATH export was intentionally removed from settings templates in 8b0cbab7
- The doctor check was causing false positives on all settings files

## Test plan

- [x] `gt doctor` now passes `claude-settings` check
- [x] `go build ./cmd/gt` compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)